### PR TITLE
Add public cloud networking/openstack neutron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 * [Software Developer, Cloud Metrics](https://github.com/rackspace/rackspace_jobs/blob/master/sfo_jobs/software_developer_cloud_metrics.md)
 * [Software Developer, Cloud Monitoring](https://github.com/rackspace/rackspace_jobs/blob/master/sfo_jobs/software_developer_cloud_monitoring.md)
 
+### [Rackspace Public Cloud Networking](https://github.com/rackspace/rackspace_jobs/tree/master/cloud_networking_jobs)
+
+* [Software Developer II, Python, Public Cloud Networking/OpenStack Neutron](https://github.com/rackspace/rackspace_jobs/blob/master/cloud_networking_jobs/neutron_jobs/python-dev-2.md)
+
 Rackspace was recently recognized by the Anita Borg institute as one of the
 [top 13 companies for women in tech](http://mashable.com/2015/04/09/women-in-tech-top-companies/).
 

--- a/cloud_networking_jobs/neutron_jobs/README.md
+++ b/cloud_networking_jobs/neutron_jobs/README.md
@@ -1,0 +1,53 @@
+Open Jobs for the Rackspace Cloud Networks Team
+
+The Rackspace Cloud Networks Team is looking for a range of skills and roles.
+Our team is responsible for leveraging open and innovative networking
+technologies to build and maintain a reliable, performant, and supportable SDN
+stack. Additionally we create tools to empower our fellow Rackers to serve our
+customers, enabling them to create meaningful on-demand and custom solutions.
+
+Some of the things our team is responsible for and has worked on in the past....
+
+* [Cloud Networks](http://www.rackspace.com/cloud/networks/)
+* [Security Groups](http://www.rackspace.com/blog/secure-your-cloud-server-deployment-with-neutron-security-groups/)
+* [OpenStack Neutron](https://wiki.openstack.org/wiki/Neutron)
+* [Quark Plugin for OpenStack Neutron](https://github.com/rackerlabs/quark)
+
+If you believe that a challenge such as this is for you then we want to talk to you!
+Please take a look at the repository for open jobs, we would love to hear from
+you if you are interested and up to the challenge.
+
+## Open Jobs:
+
+**Don't be daunted by skills / requirements: if you even know 70% of what we've
+outlined, you're welcome to apply. Our team thrives off of mentoring one another
+and growing. Of course, if you're senior - we expect you to mentor developers
+earlier in their careers**
+
+* [Python dev position](https://github.com/jmeridth/rackspace_cloudnetworking_jobs/blob/master/python-dev-2.md)
+
+Rackspace was recently recognized by the Anita Borg institute as one of the
+[top 13 companies for women in tech](http://mashable.com/2015/04/09/women-in-tech-top-companies/).
+
+**Equal Employment Opportunity Policy**: Rackspace is committed to offering equal employment opportunity without regard to age, color, disability, gender, gender identity, genetic information, marital status, military status, national origin, race, religion, sexual orientation, veteran status, or any other legally protected characteristic.
+
+## To apply, email your resume to:
+
+[Jason Meridth](mailto:jason.meridth@rackspace.com). No agencies or recruiters, please.
+
+
+If you see something odd, you can also submit a pull request to fix, or file an
+issue if there's a bug!
+
+## Who is the "Cloud Networks Team"?
+|Role|Github|
+|---    |---    |
+|**Developer**|![roaet](https://avatars2.githubusercontent.com/u/312320?v=3&s=20) [roaet](https://github.com/roaet)|
+|**Developer** |![asadoughi](https://avatars3.githubusercontent.com/u/775631?v=3&s=20) [asadoughi](https://github.com/asadoughi)|
+|**Developer**|![mpath](https://avatars1.githubusercontent.com/u/4673268?v=3&s=20) [mpath](https://github.com/mpath)|
+|**Developer**|![cerberus98](https://avatars1.githubusercontent.com/u/86828?v=3&s=20)  [cerberus98](https://github.com/cerberus98)|
+|**Dev Ops**| [quadewarren](https://github.com/quadewarren)|
+
+---
+
+<img src="http://i.imgur.com/koapmwg.png" />

--- a/cloud_networking_jobs/neutron_jobs/python-dev-2.md
+++ b/cloud_networking_jobs/neutron_jobs/python-dev-2.md
@@ -1,0 +1,38 @@
+# Python Developer
+
+Are you a Software Engineer who is passionate about building out next generation cloud scale networking software? Do you enjoy working on open source projects with large scale deployments? If so, the Rackspace cloud networking team is looking for you.
+
+You’ll work closely with both internal and external teams to push the boundaries of software based networking.  By providing both community and company support to deliver the best of class features from concept to production, you will increase Rackspace’s value proposition.  
+
+**This position is available to remote workers (US or UK). US developers can also relocate to one of our offices in Austin TX, San Antonio TX, San Francisco CA, or Blacksburg VA; UK developers are free to relocate to our office in Hayes, West London.**
+
+### Ideal candidates have:
+- Experience in several programming languages with a high proficiency in Python.
+- Broad understanding of Cloud Computing and Infrastructure as a Service. Exposure to OpenStack and the Rackspace Cloud is hugely advantageous or equivalent (AWS, Azure/Hyper-V).
+- Experience with configuration automation tools such as Ansible, Puppet and/or Chef or similar technologies.
+- Demonstration of technical leadership at a Business Unit/Company wide level.
+- Experience working with senior leadership and product management in defining product direction.
+- Ability to handle multiple tasks and prioritize work in order to maintain required productivity levels.
+- Great communication skills, empathy and patience.
+- An interest in expanding technical knowledge
+- Experience with Open Source development tools and methodologies.
+- Understanding of RESTful APIs.
+- Experience with mentoring/leading small and large teams from a technical perspective.
+
+
+### Responsibilities
+
+- Contribute to the measurement, stability and reliability of the networking stack on our public cloud.
+- Develop tools to enable our support organization to effectively support the products that we create.
+- Work with the team to develop new software based networking technologies and Network Function virtualization.
+- Contribute back to the community by attending meetups, speaking at conferences, and sharing your ideas in blog posts.
+
+
+
+**Don't be daunted by skills / requirements: if you even know 70% of what we've
+outlined, you're welcome to apply. Our team thrives off of mentoring one another
+and growing. Of course, if you're senior - we expect you to mentor developers
+earlier in their careers**
+
+Please email your resume/github/linkedin (your choice!) to [Jason Meridth](mailto:jason.meridth@rackspace.com). No agencies
+or recruiters, please.


### PR DESCRIPTION
Centralizing.  Used to be located at https://github.com/jmeridth/rackspace_cloudnetworking_jobs