### PR TITLE
Rework a lot of the Auto Scale job description

### DIFF
--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -1,13 +1,12 @@
 ## Software Developer, Autoscaling
 
-Are you a skilled and passionate Python developer looking for a new challenge in the cloud environment?  Do you want to work on a diverse team of smart and creative software developers?  Are you interested in working with an established… but not too big… company that’s re-inventing the marketplace, rated as one of Glassdoor’s “20 Best Places to work”?  Do you like otters?
+Are you a skilled and passionate Python developer looking for a new challenge in the cloud environment?  Do you want to work on a diverse team of smart and creative software developers?  Are you interested in working with an established—but not too big—company that’s re-inventing the marketplace, rated as one of Glassdoor’s “20 Best Places to work”?  Do you like otters?
 
-The Rackspace Cloud provides companies of all sizes with a web services platform in the cloud. With the Rackspace Cloud you can purchase compute power, storage and other services through our suite of infrastructure services as your business demands them. While we are launching the leading elements of this product line we are still in the early stages of the build out of the Rackspace Cloud and cloud computing in general.
+The Rackspace Cloud provides companies of all sizes with a web services platform in the cloud. With the Rackspace Cloud you can purchase compute power, storage and other services through our suite of infrastructure services as your business demands them.
 
 At Rackspace, we pride ourselves in providing a great work environment with flexible hours, talented team members, and cutting edge technology.  The successful candidate should be able to:
 
-* Design cutting edge distributed architectures and develop for large-scale cloud-based 
-systems
+* Design cutting edge distributed architectures and develop for large-scale cloud-based systems
 * Design and build back end systems that can efficiently process large volumes of data while maintaining high levels of performance under heavy loads and high 9s
 * Think creatively about new technologies, providing new solutions to old problems or identifying new problems/opportunities
 * Invent libraries, processes, etc., with a focus on delivering high-value products to internal and external customers
@@ -19,16 +18,14 @@ systems
 * 8+ years expertise in Python
 * 4-6 years experience with event-driven or async frameworks
 * Experience in delivering service-based products, deployed to large user bases
-* Prior experience in Test Driven Development, Paired Programming methodologies,
-Scrum, Kanban, etc.
+* Prior experience in Test Driven Development, Paired Programming methodologies, Scrum, Kanban, etc.
 * Strong analytical thinking and problem solving skills and experience
 * Experience with Twisted/asynchronous programming and/or parallelizing code
 * Existing OpenStack contributor status a bonus
 * Experience with numpy, hadoop, storm, spark, or machine learning is a bonus
 * Gets things done, all the way done
 * Energetically discuss and debate technical opinions in a group setting
-* Maintain a collaborative working relationship with others by seeking, using and giving
-feedback
+* Maintain a collaborative working relationship with others by seeking, using and giving feedback
 * Actively engage and collaborate with those outside own team
 * BS/MS in Computer Science or equivalent experience
 

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -13,6 +13,8 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Write clean, maintainable code using good engineering practices (distributed version control, test-driven development, peer reviews, continuous integration, automated testing, etc.)
 * Create general-purpose libraries and services, useful to other teams in the company, as well as to the open source community
 
+Our code is open source, so you can keep us honest. Check it out at https://github.com/rackerlabs/otter.
+
 ### Responsibilities
 * Learn!
 * Write Python code that's ready to be deployed and maintained

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -18,7 +18,7 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * 8+ years expertise in Python
 * 4-6 years experience with event-driven or async frameworks
 * Experience in delivering service-based products, deployed to large user bases
-* Prior experience in Test Driven Development, Paired Programming methodologies, Scrum, Kanban, etc.
+* Prior experience in Test Driven Development, Pair Programming methodologies, Scrum, Kanban, etc.
 * Strong analytical thinking and problem solving skills and experience
 * Experience with Twisted/asynchronous programming and/or parallelizing code
 * Existing OpenStack contributor status a bonus

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -15,7 +15,7 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Write clean, maintainable code using the best engineering practices in the industry (DVCS, design patterns, TDD, peer reviews, continuous integration, automated testing, etc.)
 
 ### Qualifications
-* Working experience of the Python programming language, or the same with at least one other high-level dynamically typed programming language
+* Working knowledge of the Python programming language, or the same with at least one other high-level dynamically typed programming language
 * Working knowledge of event-driven/asynchronous programming
 * Experience in delivering service-based products, deployed to large user bases
 * Prior experience in Test Driven Development, Pair Programming methodologies

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -4,15 +4,14 @@ Are you a skilled and passionate Python developer looking for a new challenge in
 
 The Rackspace Cloud provides companies of all sizes with a web services platform in the cloud. With the Rackspace Cloud you can purchase compute power, storage and other services through our suite of infrastructure services as your business demands them.
 
-At Rackspace, we pride ourselves in providing a great work environment with flexible hours, talented team members, and cutting edge technology.  The successful candidate should be able to:
+At Rackspace, we pride ourselves in providing a great work environment with flexible hours, talented team members, and cutting edge technology.  Our team strives to do the following:
 
-* Design cutting edge distributed architectures and develop for large-scale cloud-based systems
-* Design and build back end systems that can efficiently process large volumes of data while maintaining high levels of performance under heavy loads and high 9s
-* Think creatively about new technologies, providing new solutions to old problems or identifying new problems/opportunities
-* Invent libraries, processes, etc., with a focus on delivering high-value products to internal and external customers
-* Help create and/or utilize large-scale infrastructure across multiple regions and data centers
-* Effectively collaborate with teams locally as well as around the globe at each stage of development
-* Write clean, maintainable code using the best engineering practices in the industry (DVCS, design patterns, TDD, peer reviews, continuous integration, automated testing, etc.)
+* Build distributed architectures and develop for large-scale cloud-based systems
+* Build back-end systems that can maintain uptime and performance under load
+* Create and utilize infrastructure across multiple regions and data centers
+* Collaborate with teams locally and remotely at each stage of development
+* Write clean, maintainable code using good engineering practices (distributed version control, test-driven development, peer reviews, continuous integration, automated testing, etc.)
+* Create general-purpose libraries and services, useful to other teams in the company, as well as to the open source community
 
 ### Responsibilities
 * Learn!
@@ -27,6 +26,7 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Experience working on a self-directing ("agile") team of multiple developers
 * Test-driven development and pair programming methodologies
 * Strong analytical thinking and problem solving skills and experience
+* Knowledge of distributed systems
 
 ### Bonus
 * Experience in delivering service-based products, deployed to large user bases
@@ -35,6 +35,10 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Actively engage and collaborate with those outside own team
 * BS/MS in Computer Science or equivalent experience
 
-PS: Contact us and we’ll tell you why our project is code-named Otter. Hint: It’s a pun.
+Please apply if you're interested in the position, regardless of how many qualifications you meet. We want to hear from you!
 
 Please email your resume/github/linkedin (your choice!) to [Ken Wronkiewicz](mailto:ken.wronkiewicz@rackspace.com). No agencies or recruiters, please.
+
+-- The Rackspace Auto Scale Team
+
+PS: Contact us and we’ll tell you why our project is code-named Otter. Hint: It’s a pun.

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -17,21 +17,22 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Learn!
 * Write Python code that's ready to be deployed and maintained
 * Communicate technical concerns clearly
-* Accept (polite) feedback graciously
+* Give and receive (polite) feedback
 * Ensure thorough quality of work through code review and automated testing
 
 ### Useful Skills and Experience
 * Working knowledge of the Python programming language, or at least one other high-level dynamically typed programming language
-* Working knowledge of event-driven/asynchronous programming, especially Twisted
+* Working knowledge of event-driven/asynchronous programming, especially [Twisted](https://twistedmatrix.com/)
 * Experience working on a self-directing ("agile") team of multiple developers
 * Test-driven development and pair programming methodologies
 * Strong analytical thinking and problem solving skills and experience
 * Knowledge of distributed systems
+* Participation in open source communities
 
 ### Bonus
 * Experience in delivering service-based products, deployed to large user bases
 * Existing OpenStack contributor status
-* Experience with numpy, hadoop, storm, spark, or machine learning
+* Experience with or interest in [NumPy](http://www.numpy.org/), [Hadoop](https://hadoop.apache.org/), [Storm](https://storm.apache.org/), [Spark](https://spark.apache.org/), or machine learning
 * Actively engage and collaborate with those outside own team
 * BS/MS in Computer Science or equivalent experience
 

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -14,19 +14,24 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Effectively collaborate with teams locally as well as around the globe at each stage of development
 * Write clean, maintainable code using the best engineering practices in the industry (DVCS, design patterns, TDD, peer reviews, continuous integration, automated testing, etc.)
 
-### Qualifications
-* Working knowledge of the Python programming language, or the same with at least one other high-level dynamically typed programming language
-* Working knowledge of event-driven/asynchronous programming
-* Experience in delivering service-based products, deployed to large user bases
-* Prior experience in Test Driven Development, Pair Programming methodologies
+### Responsibilities
+* Learn!
+* Write Python code that's ready to be deployed and maintained
+* Communicate technical concerns clearly
+* Accept (polite) feedback graciously
+* Ensure thorough quality of work through code review and automated testing
+
+### Useful Skills and Experience
+* Working knowledge of the Python programming language, or at least one other high-level dynamically typed programming language
+* Working knowledge of event-driven/asynchronous programming, especially Twisted
 * Experience working on a self-directing ("agile") team of multiple developers
+* Test-driven development and pair programming methodologies
 * Strong analytical thinking and problem solving skills and experience
-* Experience with Twisted/asynchronous programming and/or parallelizing code
-* Existing OpenStack contributor status a bonus
-* Experience with numpy, hadoop, storm, spark, or machine learning is a bonus
-* Gets things done, all the way done
-* Energetically discuss and debate technical opinions in a group setting
-* Maintain a collaborative working relationship with others by seeking, using and giving feedback
+
+### Bonus
+* Experience in delivering service-based products, deployed to large user bases
+* Existing OpenStack contributor status
+* Experience with numpy, hadoop, storm, spark, or machine learning
 * Actively engage and collaborate with those outside own team
 * BS/MS in Computer Science or equivalent experience
 

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -18,7 +18,8 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * 8+ years expertise in Python
 * 4-6 years experience with event-driven or async frameworks
 * Experience in delivering service-based products, deployed to large user bases
-* Prior experience in Test Driven Development, Pair Programming methodologies, Scrum, Kanban, etc.
+* Prior experience in Test Driven Development, Pair Programming methodologies
+* Experience working on a self-directing ("agile") team of multiple developers
 * Strong analytical thinking and problem solving skills and experience
 * Experience with Twisted/asynchronous programming and/or parallelizing code
 * Existing OpenStack contributor status a bonus

--- a/sfo_jobs/software_developer_autoscale.md
+++ b/sfo_jobs/software_developer_autoscale.md
@@ -15,8 +15,8 @@ At Rackspace, we pride ourselves in providing a great work environment with flex
 * Write clean, maintainable code using the best engineering practices in the industry (DVCS, design patterns, TDD, peer reviews, continuous integration, automated testing, etc.)
 
 ### Qualifications
-* 8+ years expertise in Python
-* 4-6 years experience with event-driven or async frameworks
+* Working experience of the Python programming language, or the same with at least one other high-level dynamically typed programming language
+* Working knowledge of event-driven/asynchronous programming
 * Experience in delivering service-based products, deployed to large user bases
 * Prior experience in Test Driven Development, Pair Programming methodologies
 * Experience working on a self-directing ("agile") team of multiple developers


### PR DESCRIPTION
It was a bit over the top (and may still be in some places)

- get rid of "8 years of Python" + "4 years of async" thing
- replace the "successful candidates will..." section with a "our team strives to..." section, and reduce the aggrandizement of the points therein
- reorganize the "Qualifications" section into three sections:
  - "Responsibilities"  - a greatly reduced core of important things we want in a candidate
  - "Useful Skills and Experience" - most of what was there in Qualifications
  - "Bonus" - particularly unnecessary-but-cool qualities
- link to our code, which is open source
- lots of other general cleanup
- implore people to apply even if they don't meet all the qualifications.


Thanks to @cyli for a lot of input into this.