### PR TITLE
adding travis-ci based joblint checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,39 @@
+var fs = require('fs');
+var joblint = require('joblint');
+
+var glob = require("glob")
+ 
+function handleInputFailure (msg) {
+    console.error(msg);
+    process.exit(1);
+}
+
+function handleInputSuccess (file, data) {
+    var result = joblint(data);
+    if ( (result.errors.length !== 0) || (result.warnings.length !== 0) ) {
+        console.log('joblint failure: ' + file);
+        console.log(result.errors);
+        console.log(result.warnings);
+        process.exit(1);
+    }
+}
+
+// options is optional 
+glob("**/*.md", {}, function (er, files) {
+    files.forEach(function(file) {
+        fs.readFile(file, {encoding: 'utf8'}, function (err, data) {
+            var re = /readme|node_modules/i;
+            if (!file.match(re)) {
+                if (err) {
+                    handleInputFailure('File "' + fileName + '" not found');
+                } else {
+                    handleInputSuccess(file, data);
+                }
+            }
+        });
+    });
+  // files is an array of filenames. 
+  // If the `nonull` option is set, and nothing 
+  // was found, then files is ["**/*.js"] 
+  // er is an error object or null. 
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rackspace_jobs",
+  "version": "1.0.0",
+  "description": "Rackspace Jobs for Developers, Engineers, Sysadmins and more ",
+  "main": "index.js",
+  "scripts": {
+    "test": "node index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rackspace/rackspace_jobs.git"
+  },
+  "author": "",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/rackspace/rackspace_jobs/issues"
+  },
+  "homepage": "https://github.com/rackspace/rackspace_jobs",
+  "dependencies": {
+    "glob": "^5.0.6",
+    "joblint": "^1.3.2"
+  }
+}


### PR DESCRIPTION
Last year, I had several interesting experiences with diverse candidates and learned a valuable lesson.  In each case, a candidate who was either a referral or had a random conversation with one of our recruiters entered our recruiting pipeline and was matched with an open position.  The candidates, upon seeing the job description they were interviewing for, told me they wouldn't have applied for the position were they to have seen it on our recruiting pipeline.

It was a valuable lesson for me, because I'd not hesitate to apply for a job that I wasn't directly qualified for.  I've used this as an opportunity to ask other related questions.. to correct my bias.

I discovered joblint and tried it against our open job descriptions here and only found a few notices.. mostly that we're using 'cutting edge'.

This branch allows us to continue to keep this repo free of language that would cause qualified applicants to not apply for open positions by setting up Travis-CI to run joblint on all job descriptions.